### PR TITLE
Add SkelterLabs to github.json

### DIFF
--- a/github.json
+++ b/github.json
@@ -618,5 +618,15 @@
         "public_repos": 7
       }
     ]
+  },
+  {
+    "name": "스켈터랩스",
+    "organizations": [
+      {
+        "followers": 4,
+        "organization_id": "SkelterLabsInc",
+        "public_repos": 14,
+      }
+     ]
   }
 ]


### PR DESCRIPTION
We, Skelter Labs, had published JaQuAD dataset through Github. Also we provide various APIs to access our SaaS AI platform.

스켈터랩스는 일본어 기계독해 데이터셋 JaQuAD 를 비롯해 저희 SaaS AI 플랫폼 등에 접근하는 예제 코드 등을 깃허브를 통해 제공하고 있습니다.