### PR TITLE
chore: Use setup-python action to cache dependencies

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -21,14 +21,14 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
 
-      - name: Install dependencies (`aiohttp`)
+      - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install aiohttp
+          python -m pip install -r requirements.txt
 
       - name: Run script
         run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+aiohttp==3.8.3
+aiosignal==1.3.1
+async-timeout==4.0.2
+attrs==22.1.0
+charset-normalizer==2.1.1
+frozenlist==1.3.3
+idna==3.4
+multidict==6.0.3
+yarl==1.8.2


### PR DESCRIPTION
## 배경

#9 

## 작업 내용

- `pip freeze > requirements.txt`를 통하여 pip 의존성 정보가 담긴 `requirements.txt`을 생성하였습니다.
- `actions/setup-python@v3`부터 의존성 캐싱 기능이 빌트인 지원되기 때문에 v3으로 변경하였습니다.
- `cache: pip` 옵션을 사용하여 python 설정 시 캐시를 복원/저장하도록 하였습니다.
- `requirements.txt`를 읽어와 의존성을 설치하도록 변경하였습니다.

## References

- [Caching dependencies to speed up workflows](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows)